### PR TITLE
DIRECTORY_SEPARATOR  windows machine problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/src/Theme/helpers.php
+++ b/src/Theme/helpers.php
@@ -12,6 +12,6 @@ if (!function_exists('theme_url')) {
     {
         $currentTheme = app('Lukeed\Theme\Contracts\ThemeInterface')->get()->getDirectory();
 
-        return app('url')->asset('themes' . DIRECTORY_SEPARATOR . $currentTheme . DIRECTORY_SEPARATOR . $path, $secure);
+        return app('url')->asset('themes' . '/' . $currentTheme . '/' . $path, $secure);
     }
 }


### PR DESCRIPTION
Now I create a small PHP Application, here I have problem for using file path, because in Windows use this type location C:\Some\Location\index but in Linux /www/app/index so when I define the path using this / but when the application run in window machine it should be problem for this /

PHP accepts both \ and / as valid path separators in all OS. So just use / in your code


more detail:
https://stackoverflow.com/questions/6619020/how-can-i-define-the-directory-separator-for-both-windows-and-linux-platforms